### PR TITLE
[bugfix] panic when no next scheduled leader

### DIFF
--- a/backrun/src/event_loops.rs
+++ b/backrun/src/event_loops.rs
@@ -1,21 +1,24 @@
+use std::{sync::Arc, time::Duration};
+
 use futures_util::StreamExt;
 use jito_protos::searcher::{PendingTxNotification, PendingTxSubscriptionRequest};
 use log::info;
 use searcher_service_client::get_searcher_client;
-use solana_client::nonblocking::pubsub_client::PubsubClient;
-use solana_client::rpc_config::{RpcBlockSubscribeConfig, RpcBlockSubscribeFilter};
-use solana_client::rpc_response;
-use solana_client::rpc_response::{RpcBlockUpdate, SlotUpdate};
+use solana_client::{
+    nonblocking::pubsub_client::PubsubClient,
+    rpc_config::{RpcBlockSubscribeConfig, RpcBlockSubscribeFilter},
+    rpc_response,
+    rpc_response::{RpcBlockUpdate, SlotUpdate},
+};
 use solana_metrics::{datapoint_error, datapoint_info};
-use solana_sdk::clock::Slot;
-use solana_sdk::commitment_config::{CommitmentConfig, CommitmentLevel};
-use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::Keypair;
+use solana_sdk::{
+    clock::Slot,
+    commitment_config::{CommitmentConfig, CommitmentLevel},
+    pubkey::Pubkey,
+    signature::Keypair,
+};
 use solana_transaction_status::{TransactionDetails, UiTransactionEncoding};
-use std::sync::Arc;
-use std::time::Duration;
-use tokio::sync::mpsc::Sender;
-use tokio::time::sleep;
+use tokio::{sync::mpsc::Sender, time::sleep};
 
 // slot update subscription loop that attempts to maintain a connection to an RPC server
 pub async fn slot_subscribe_loop(pubsub_addr: String, slot_sender: Sender<Slot>) {

--- a/searcher_service_client/src/lib.rs
+++ b/searcher_service_client/src/lib.rs
@@ -1,13 +1,19 @@
-use crate::token_authenticator::ClientInterceptor;
-use jito_protos::auth::auth_service_client::AuthServiceClient;
-use jito_protos::auth::Role;
-use jito_protos::searcher::searcher_service_client::SearcherServiceClient;
-use solana_sdk::signature::Keypair;
 use std::sync::Arc;
+
+use jito_protos::{
+    auth::{auth_service_client::AuthServiceClient, Role},
+    searcher::searcher_service_client::SearcherServiceClient,
+};
+use solana_sdk::signature::Keypair;
 use thiserror::Error;
-use tonic::codegen::InterceptedService;
-use tonic::transport::{Channel, Endpoint};
-use tonic::{transport, Status};
+use tonic::{
+    codegen::InterceptedService,
+    transport,
+    transport::{Channel, Endpoint},
+    Status,
+};
+
+use crate::token_authenticator::ClientInterceptor;
 
 pub mod token_authenticator;
 

--- a/searcher_service_client/src/token_authenticator.rs
+++ b/searcher_service_client/src/token_authenticator.rs
@@ -1,8 +1,8 @@
-use std::sync::RwLock;
-use std::time::SystemTime;
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{Arc, RwLock},
+    time::{Duration, SystemTime},
+};
 
-use crate::BlockEngineConnectionResult;
 use jito_protos::auth::{
     auth_service_client::AuthServiceClient, GenerateAuthChallengeRequest,
     GenerateAuthTokensRequest, RefreshAccessTokenRequest, Role, Token,
@@ -12,6 +12,8 @@ use solana_metrics::datapoint_info;
 use solana_sdk::signature::{Keypair, Signer};
 use tokio::{task::JoinHandle, time::sleep};
 use tonic::{service::Interceptor, transport::Channel, Request, Status};
+
+use crate::BlockEngineConnectionResult;
 
 const AUTHORIZATION_HEADER: &str = "authorization";
 const BEARER: &str = "Bearer ";


### PR DESCRIPTION
When no leader connected, seeing:

`[2022-09-19T08:16:54.454007Z INFO  solana_metrics::metrics] datapoint: slot_subscribe_slot slot=151871410i
thread 'main' panicked at 'attempt to subtract with overflow', backrun/src/main.rs:242:9`