### PR TITLE
Bring back signature awaiting for bundle confirmation

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -17,6 +17,7 @@ use jito_searcher_client::{
 use log::info;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::{
+    commitment_config::CommitmentConfig,
     pubkey::Pubkey,
     signature::{read_keypair_file, Signer},
     system_instruction::transfer,
@@ -228,7 +229,7 @@ async fn main() {
         } => {
             let payer_keypair = read_keypair_file(payer).expect("reads keypair at path");
             let tip_account = Pubkey::from_str(&tip_account).expect("valid pubkey for tip account");
-            let rpc_client = RpcClient::new(rpc_url);
+            let rpc_client = RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed());
             let balance = rpc_client
                 .get_balance(&payer_keypair.pubkey())
                 .await

--- a/searcher_client/src/lib.rs
+++ b/searcher_client/src/lib.rs
@@ -126,7 +126,6 @@ pub async fn send_bundle_with_confirmation(
                             CommitmentConfig::processed(),
                         )
                     })
-                    .clone()
                     .collect();
                 let results = futures::future::join_all(futs).await;
                 if !results.iter().all(|r| matches!(r, Ok(Some(Ok(()))))) {

--- a/searcher_client/src/lib.rs
+++ b/searcher_client/src/lib.rs
@@ -1,5 +1,4 @@
 use std::{
-    str::FromStr,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -24,9 +23,8 @@ use solana_sdk::{
     signature::{Keypair, Signature},
     transaction::VersionedTransaction,
 };
-use solana_transaction_status::EncodedTransaction;
 use thiserror::Error;
-use tokio::time::{sleep, timeout};
+use tokio::time::timeout;
 use tonic::{
     codegen::InterceptedService,
     transport,


### PR DESCRIPTION
`rpc_client.get_block` was too slow to get the blocks, so go back to this method for confirming bundles