### PR TITLE
bugfix: fix backrun example

### DIFF
--- a/backrun/src/main.rs
+++ b/backrun/src/main.rs
@@ -151,7 +151,7 @@ fn build_bundles(
                             .as_bytes(),
                         &[],
                     ),
-                    transfer(&keypair.pubkey(), &tip_account, 1),
+                    transfer(&keypair.pubkey(), &tip_account, 10_000),
                 ],
                 Some(&keypair.pubkey()),
                 &[keypair],


### PR DESCRIPTION
backrun example only tips 1 lamport, meaning they won't get accepted. tip more.