### PR TITLE
fix: no auth subscription must only wait for the expected bundle ID.

### DIFF
--- a/searcher_client/src/lib.rs
+++ b/searcher_client/src/lib.rs
@@ -1,7 +1,4 @@
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{future, sync::Arc, time::{Duration, Instant}};
 
 use futures_util::StreamExt;
 use jito_protos::{
@@ -120,7 +117,9 @@ where
     let mut time_left = 5000;
     while let Ok(Some(Ok(results))) = timeout(
         Duration::from_millis(time_left),
-        bundle_results_subscription.next(),
+        bundle_results_subscription
+            .filter(|bundle_result| future::ready(matches!(bundle_result, Ok(bundle) if bundle.bundle_id == uuid)))
+            .next(),
     )
     .await
     {


### PR DESCRIPTION
### Overview
When `jito-searcher-cli send-bundle` is run in no-auth mode, the `bundle_results_subscription`
https://github.com/jito-labs/searcher-examples/blob/3708a1ebc527e5376a2331faffc9d3ddc658a145/cli/src/main.rs#L257

emits other searchers' bundles.

The current code subscribes to the only `.next()` bundle
https://github.com/jito-labs/searcher-examples/blob/ab969955dbb486cd9ca44c9db276a1f3c010f252/searcher_client/src/lib.rs#L122
even though it is not necessarily the signer's bundle.

So the script fails with an error akin to:

```
Sending bundle failed: SimulationFailure("Kze3b5YyyHCPvD8TRRQUdHuXT1Ch6dmUUPYsaC6qSTfyGzxpkjnGkD8xgCQXyDoAC71FZyuU7aXYzJXAqgJm8QB", Some("A transaction in the bundle failed to execute: [signature=Kze3b5YyyHCPvD8TRRQUdHuXT1Ch6dmUUPYsaC6qSTfyGzxpkjnGkD8xgCQXyDoAC71FZyuU7aXYzJXAqgJm8QB, error=Error processing Instruction 3: custom program error: 0x7d0]"))
```

### Fix
Expect only the sent bundle by UUID and filter out everything else.