### PR TITLE
Provide correct SOLSCAN cluster url in searcher_client example

### DIFF
--- a/searcher_client/src/lib.rs
+++ b/searcher_client/src/lib.rs
@@ -184,8 +184,16 @@ where
         )));
     }
     info!("Bundle landed successfully");
+    let url: String = rpc_client.url();
+    let cluster = if url.contains("testnet") {
+        "testnet"
+    } else if url.contains("devnet") {
+        "devnet"
+    } else {
+        "mainnet"
+    };
     for sig in bundle_signatures.iter() {
-        info!("https://solscan.io/tx/{}", sig);
+        info!("https://solscan.io/tx/{}?cluster={}", sig, cluster);
     }
     Ok(())
 }


### PR DESCRIPTION
If someone is sending to devnet or testnet, currently transaction will not be found with the provided URL.