### PR TITLE
Update usage since we no longer support mempool features

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Backrunning is when one inserts a transaction immediately behind a target transa
 
 This example listens to transactions from the mempool and submits bundles containing a backrun transaction immediately behind a target transaction.
 
+Due to the deprecation of mempool features, support for this functionality has been discontinued.
+
 ### cli
 This is a rust program that exercises functionality inside the searcher API so you can explore the functionality. It provides an intuitive CLI-based interface for connecting to the block engine and sending test bundles.
 


### PR DESCRIPTION
Since we no longer support mempool usage, update the README to make this clear. 

```
[ERROR solana_metrics::metrics] datapoint: searcher_pending_tx_sub_error errors=1i error_str="status: Unimplimented, message: \"subscribe_mempool is deprecated\", details: [], metadata: MetadataMap { headers: {\"content-type\": \"application/grpc\", \"server\": \"jito-block-engine\", \"x-envoy-upstream-service-time\": \"0\", \"content-length\": \"0\"} }"
```