### PR TITLE
Update leader slot usage

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -21,6 +21,8 @@ cargo b --release --bin jito-searcher-cli
 
 ### Get the next scheduled leader
 
+(Note: This check is no longer needed since Jito-Sol is on roughly 80% of validators. If this were to drop below 50% this check might be more useful)
+
 Returns the pubkey of the next scheduled leader.
 
 ```bash

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -261,6 +261,7 @@ where
                 .into_inner();
 
             // wait for jito-solana leader slot
+            // note: this check is not needed unless jito-solana controls less than 50% of validators
             let mut is_leader_slot = false;
             while !is_leader_slot {
                 let next_leader = client


### PR DESCRIPTION
Since jito-solana is on roughly 80% of the validators, make it clear to users that this check is not needed unless the jito-sol validator network is less than 50%.